### PR TITLE
Don't check if a transpiler patch was applied before applying it. 

### DIFF
--- a/Source/Patches/InspectGizmoGrid_DrawInspectGizmoGridFor_Patch.cs
+++ b/Source/Patches/InspectGizmoGrid_DrawInspectGizmoGridFor_Patch.cs
@@ -54,6 +54,7 @@ namespace AllowTool.Patches {
 			var currentDesignatorHolderIndex = -1;
 			var currentCommandIndex = -1;
 			var prechecksSuccess = false;
+			patchApplied = false;
 			// find indices of local vars. They could be hardcoded, but this method is more future-proof
 			try {
 				CodeInstruction prevInstruction = null;
@@ -84,7 +85,7 @@ namespace AllowTool.Patches {
 			// currentDesignatorHolderIndex: 10 
 			foreach (var instruction in instructionsArr) {
 				yield return instruction;
-				if (prechecksSuccess && !patchApplied) {
+				if (prechecksSuccess) {
 					// after the group key for the command is set
 					if (instruction.opcode == OpCodes.Stfld && commandGroupKeyField.Equals(instruction.operand)) {
 						// push reference to designator reference holder


### PR DESCRIPTION
This breaks if two mods transpile the same method (e.g. https://github.com/alextd/RimWorld-WhatIsMyPurpose/blob/c54ce65d81b95881a08278c52764868f4bee56d8/Source/TargetGizmo.cs#L233).

Both  transpilers get called again on a fresh copy of the method, tossing out the original transpile (perhaps for priority's sake, the order might change and the original may be invalid).

So the second call to the transpiler here would see the global bool as "patched" and not apply the patch.

Of course if the load order put Allowtools second, it would not be the "second" time, and the patch would apply.

(Perhaps Harmony should wait to transpiling until all mods define their patches, but also transpilers don't need to check if they're already run)