### PR TITLE
Conflict with Save Our Ship 2

### DIFF
--- a/Source/PartyHuntController.cs
+++ b/Source/PartyHuntController.cs
@@ -21,7 +21,7 @@ namespace AllowTool {
 		private static readonly List<HuntingTargetCandidate> huntingTargetCandidates = new List<HuntingTargetCandidate>();
 
 		public static Gizmo TryGetGizmo(Pawn pawn) {
-			if (!pawn.Drafted || !AllowToolController.Instance.PartyHuntSetting) return null;
+			if (pawn.Name == null || !pawn.Drafted || !AllowToolController.Instance.PartyHuntSetting) return null;
 			return new Command_PartyHunt(pawn);
 		}
 


### PR DESCRIPTION
There is a problem with Save Our Ship 2 mod. When a shuttle is selected to hover, it will become a `Pawn` so it can move on the map. The problem is, the pawn-like shuttles lack a `Name`. This causes the group hunt `Gizmo` constructor to throw a null pointer exception.

This PR will prevent group hunt constructor from being called by first verifying the pawn has a `Name`. If the pawn does not have a `Name` this change will prevent a `Gizmo` from being created for hunting.