### PR TITLE
Add the new "AllWork" tag to both TypeDefs

### DIFF
--- a/Mods/AllowTool/Defs/WorkTypeDefs/AllowToolWorkTypes.xml
+++ b/Mods/AllowTool/Defs/WorkTypeDefs/AllowToolWorkTypes.xml
@@ -13,6 +13,7 @@
 		<workTags>
 			<li>ManualDumb</li>
 			<li>Hauling</li>
+			<li>AllWork</li>
 		</workTags>
 	</WorkTypeDef>
 
@@ -31,6 +32,7 @@
 		</relevantSkills>
 		<workTags>
 			<li>Violent</li>
+			<li>AllWork</li>
 		</workTags>
 	</WorkTypeDef>
 


### PR DESCRIPTION
"AllWork" is a tag which is used to let Royalty's "Lazy Guests" who don't do any work know what is and isn't work.  For whatever reason Tynan chose to define "AllWork" explicitly for every job that exists except two, instead of just saying Bedrest and Patient are "NotWork" or something.  As a result, every modded WorkTypeDef which represents labor of any sort needs these tags added, or else you can make guests do it which is kind of an exploit.

Regardless, unused tags don't cause any issues as far as I've been able to determine, so this should be a perfectly backwards compatible fix too, with or without Royalty.