### PR TITLE
Dont Drafted Hunt Animals to be Tamed

### DIFF
--- a/Source/Handlers/PartyHuntHandler.cs
+++ b/Source/Handlers/PartyHuntHandler.cs
@@ -18,7 +18,7 @@ namespace AllowTool {
 
 		// stop attacking and don't target downed animals if auto finish off is enabled
 		private static readonly HuntingTargetFilter HuntingTargetAttackFilter = 
-			(target, hunter) => !target.Downed || (CanDoCommonerWork(hunter) && !WorldSettings.AutoFinishOff);
+			(target, hunter) => !target.HasDesignation(DesignationDefOf.Tame) && (!target.Downed || (CanDoCommonerWork(hunter) && !WorldSettings.AutoFinishOff));
 		private static readonly HuntingTargetFilter HuntingTargetFinishFilter = 
 			(target, _) => target.Downed && !target.HasDesignation(AllowToolDefOf.FinishOffDesignation);
 		private static readonly List<HuntingTargetCandidate> huntingTargetCandidates = new List<HuntingTargetCandidate>();


### PR DESCRIPTION
## Dont Drafted Hunt Animals to be Tamed

#### Before this change

There is no straightforward way to prevent your drafted hunt team from attacking an animal that you clearly don't want to kill because it is designated for Tame.

#### After this change

The inverse is much easier: if you really want your squad to kill it, just manually tell them to attack it, or remove the Tame designator from it.